### PR TITLE
Add geometry density render feature

### DIFF
--- a/Assets/Resources/GeometryDensityBlend.shader
+++ b/Assets/Resources/GeometryDensityBlend.shader
@@ -1,0 +1,46 @@
+Shader "Hidden/GeometryDensity/Blend"
+{
+    SubShader
+    {
+        Tags { "RenderPipeline"="UniversalRenderPipeline" "RenderType"="Opaque" }
+        Pass
+        {
+            ZTest Always Cull Off ZWrite Off
+            Blend SrcAlpha OneMinusSrcAlpha
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            TEXTURE2D(_BaseTex);
+            SAMPLER(sampler_BaseTex);
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            Varyings vert(Attributes v)
+            {
+                Varyings o;
+                o.vertex = TransformObjectToHClip(v.positionOS.xyz);
+                o.uv = v.uv;
+                return o;
+            }
+
+            half4 frag(Varyings i) : SV_Target
+            {
+                return SAMPLE_TEXTURE2D(_BaseTex, sampler_BaseTex, i.uv);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Resources/GeometryDensityBlend.shader
+++ b/Assets/Resources/GeometryDensityBlend.shader
@@ -13,8 +13,8 @@ Shader "Hidden/GeometryDensity/Blend"
             #pragma fragment frag
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
-            TEXTURE2D(_BaseTex);
-            SAMPLER(sampler_BaseTex);
+            TEXTURE2D(_BlitTexture);
+            SAMPLER(sampler_BlitTexture);
 
             struct Attributes
             {
@@ -38,7 +38,7 @@ Shader "Hidden/GeometryDensity/Blend"
 
             half4 frag(Varyings i) : SV_Target
             {
-                return SAMPLE_TEXTURE2D(_BaseTex, sampler_BaseTex, i.uv);
+                return SAMPLE_TEXTURE2D(_BlitTexture, sampler_BlitTexture, i.uv);
             }
             ENDHLSL
         }

--- a/Assets/Resources/GeometryDensityBlend.shader.meta
+++ b/Assets/Resources/GeometryDensityBlend.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 887fbc2cf52e40e7bbdfc22167afbf1e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/GeometryDensityOverlay.compute
+++ b/Assets/Resources/GeometryDensityOverlay.compute
@@ -1,0 +1,14 @@
+#pragma kernel CSMain
+
+RWTexture2D<float4> Result;
+float4 _Color;
+
+[numthreads(8,8,1)]
+void CSMain(uint3 id : SV_DispatchThreadID)
+{
+    uint width, height;
+    Result.GetDimensions(width, height);
+    if (id.x >= width || id.y >= height)
+        return;
+    Result[id.xy] = _Color;
+}

--- a/Assets/Resources/GeometryDensityOverlay.compute.meta
+++ b/Assets/Resources/GeometryDensityOverlay.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f0f0fd0c8da409f994076deb331d701
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/DebugS/GeometryDensityDebugger.cs
+++ b/Assets/Scripts/DebugS/GeometryDensityDebugger.cs
@@ -1,0 +1,105 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+public class GeometryDensityDebugger : ScriptableRendererFeature
+{
+    [System.Serializable]
+    public class Settings
+    {
+        public float threshold = 0.5f;
+        public Color withinColor = new Color(0f, 1f, 0f, 0.2f);
+        public Color exceedColor = new Color(1f, 0f, 0f, 0.2f);
+    }
+
+    class GeometryDensityPass : ScriptableRenderPass
+    {
+        ComputeShader compute;
+        Shader blendShader;
+        Settings settings;
+        int overlayID = Shader.PropertyToID("_GeometryDensityOverlay");
+        Material blendMaterial;
+
+        public GeometryDensityPass(ComputeShader compute, Shader blendShader, Settings settings)
+        {
+            this.compute = compute;
+            this.blendShader = blendShader;
+            this.settings = settings;
+            if (blendShader != null)
+                blendMaterial = CoreUtils.CreateEngineMaterial(blendShader);
+        }
+
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        {
+            var desc = renderingData.cameraData.cameraTargetDescriptor;
+            desc.enableRandomWrite = true;
+            desc.depthBufferBits = 0;
+            cmd.GetTemporaryRT(overlayID, desc, FilterMode.Point);
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (compute == null || blendMaterial == null)
+                return;
+
+            Camera cam = renderingData.cameraData.camera;
+            int totalVertices = 0;
+            foreach (var r in Object.FindObjectsOfType<Renderer>())
+            {
+                if (!r.isVisible)
+                    continue;
+                var mf = r.GetComponent<MeshFilter>();
+                if (mf != null && mf.sharedMesh != null)
+                    totalVertices += mf.sharedMesh.vertexCount;
+                var smr = r as SkinnedMeshRenderer;
+                if (smr != null && smr.sharedMesh != null)
+                    totalVertices += smr.sharedMesh.vertexCount;
+            }
+            float screenArea = (float)cam.pixelWidth * cam.pixelHeight;
+            float ratio = screenArea > 0 ? totalVertices / screenArea : 0f;
+            Color overlayColor = ratio > settings.threshold ? settings.exceedColor : settings.withinColor;
+
+            int kernel = compute.FindKernel("CSMain");
+            CommandBuffer cmd = CommandBufferPool.Get("GeometryDensity");
+            cmd.SetComputeVectorParam(compute, "_Color", overlayColor);
+            cmd.SetComputeTextureParam(compute, kernel, "Result", overlayID);
+            int tgx = Mathf.CeilToInt(cam.pixelWidth / 8f);
+            int tgy = Mathf.CeilToInt(cam.pixelHeight / 8f);
+            cmd.DispatchCompute(compute, kernel, tgx, tgy, 1);
+
+            var source = renderingData.cameraData.renderer.cameraColorTarget;
+            Blit(cmd, overlayID, source, blendMaterial);
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+
+        public override void OnCameraCleanup(CommandBuffer cmd)
+        {
+            if (cmd == null) return;
+            cmd.ReleaseTemporaryRT(overlayID);
+        }
+    }
+
+    public Settings settings = new Settings();
+    ComputeShader computeShader;
+    Shader blendShader;
+    GeometryDensityPass pass;
+
+    public override void Create()
+    {
+        computeShader = Resources.Load<ComputeShader>("GeometryDensityOverlay");
+        blendShader = Resources.Load<Shader>("GeometryDensityBlend");
+        pass = new GeometryDensityPass(computeShader, blendShader, settings)
+        {
+            renderPassEvent = RenderPassEvent.AfterRendering
+        };
+    }
+
+    public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
+    {
+        if (computeShader == null || blendShader == null)
+            return;
+        renderer.EnqueuePass(pass);
+    }
+}

--- a/Assets/Scripts/DebugS/GeometryDensityDebugger.cs
+++ b/Assets/Scripts/DebugS/GeometryDensityDebugger.cs
@@ -8,8 +8,8 @@ public class GeometryDensityDebugger : ScriptableRendererFeature
     public class Settings
     {
         public float threshold = 0.5f;
-        public Color withinColor = new Color(0f, 1f, 0f, 0.2f);
-        public Color exceedColor = new Color(1f, 0f, 0f, 0.2f);
+        public Color withinColor = new Color(0f, 1f, 0f, 0.4f);
+        public Color exceedColor = new Color(1f, 0f, 0f, 0.4f);
     }
 
     class GeometryDensityPass : ScriptableRenderPass
@@ -33,6 +33,8 @@ public class GeometryDensityDebugger : ScriptableRendererFeature
         {
             var desc = renderingData.cameraData.cameraTargetDescriptor;
             desc.enableRandomWrite = true;
+            desc.msaaSamples = 1; // compute shaders cannot write to MSAA targets
+            desc.graphicsFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.R8G8B8A8_UNorm;
             desc.depthBufferBits = 0;
             cmd.GetTemporaryRT(overlayID, desc, FilterMode.Point);
         }

--- a/Assets/Scripts/DebugS/GeometryDensityDebugger.cs.meta
+++ b/Assets/Scripts/DebugS/GeometryDensityDebugger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d0b65b6216347818faed61ecc5a78c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Settings/URP-Performant-Renderer.asset
+++ b/Assets/Settings/URP-Performant-Renderer.asset
@@ -20,6 +20,22 @@ MonoBehaviour:
   passIndex: 0
   bindDepthStencilAttachment: 0
   m_Version: 1
+--- !u!114 &-412825555123456789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d0b65b6216347818faed61ecc5a78c2, type: 3}
+  m_Name: GeometryDensityDebugger
+  m_EditorClassIdentifier:
+  settings:
+    threshold: 0.5
+    withinColor: {r: 0, g: 1, b: 0, a: 0.4}
+    exceedColor: {r: 1, g: 0, b: 0, a: 0.4}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -38,6 +54,7 @@ MonoBehaviour:
     hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
   m_RendererFeatures:
   - {fileID: -484357092785402811}
+  - {fileID: -412825555123456789}
   m_RendererFeatureMap: 45cc1554ca3747f9
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}


### PR DESCRIPTION
## Summary
- replace previous overlay script with `GeometryDensityDebugger` render feature
- use compute shader `GeometryDensityOverlay.compute` to fill overlay texture
- blend result using `GeometryDensityBlend.shader`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684856f1b78083228a63d4a36433a43b